### PR TITLE
split socket concerns

### DIFF
--- a/api/games/api_games.py
+++ b/api/games/api_games.py
@@ -7,7 +7,7 @@ from ..decorators import jwt_required
 import jwt
 import os
 import json
-from websockets.socket import new_game_notice, join_game_notice
+from websockets.roomSocket import new_game_notice, join_game_notice
 
 api_games = Blueprint('api_games', __name__, url_prefix='/api/games')
 

--- a/api/rooms/api_rooms.py
+++ b/api/rooms/api_rooms.py
@@ -4,7 +4,7 @@ from models.GameRoom import GameRoom, rooms_schema, room_schema
 from models.Game import Game, games_schema
 from database import db
 from ..decorators import jwt_required
-from websockets.socket import new_room_notice, join_room_notice
+from websockets.roomSocket import new_room_notice, join_room_notice
 
 api_rooms = Blueprint('api_rooms', __name__, url_prefix='/api/rooms')
 

--- a/websockets/roomSocket.py
+++ b/websockets/roomSocket.py
@@ -1,0 +1,24 @@
+from app import socketio
+from flask_socketio import send, emit, join_room, leave_room
+import json
+
+def join_room_notice(room):
+    @socketio.on('join room', namespace=f'/{room}')
+    def connect_room(message):
+        print(f'connected with ${message}')
+        emit('connected', {'roomspace': f'/{room}'})
+
+def new_game_notice(room, game):
+    print('sending new game notice')
+    socketio.emit('new game', game, broadcast=True, namespace=f'/{room}')
+
+
+def new_room_notice(room):
+    socketio.emit('new room', room, broadcast=True)
+
+def join_game_notice(game_id, user):
+    @socketio.on('join game')
+    def return_join_game_notice(data):
+        game = data['game']
+        join_room(game)
+        emit('join game', data, room=f'game')

--- a/websockets/socket.py
+++ b/websockets/socket.py
@@ -13,7 +13,7 @@ def handle_connection():
     ''')
     emit('message', {'data':'connection'}, broadcast=True)
 
-@socketio.on('message')
+@socketio.on('send message')
 def handle_message(message):
     print(message)
     emit('init namespace', {'namespace':'newroom'})
@@ -25,32 +25,3 @@ def handle_connection():
     look cool a namespaced socketio connection!
 
     ''')
-
-# ! Game Room Messages
-
-def join_room_notice(room):
-    @socketio.on('connect', namespace=f'/{room}')
-    def room_socket_mount():
-        print(f'/{room} socket mounted')
-    @socketio.on('join room', namespace=f'/{room}')
-    def connect_room(message):
-        print(f'connected with ${message}')
-        emit('connected', {'roomspace': f'/{room}'})
-
-def new_game_notice(room, game):
-    socketio.emit('new game', game, broadcast=True, namespace=f'/{room}')
-
-
-def new_room_notice(room):
-    socketio.emit('new room', room, broadcast=True)
-
-def join_game_notice(game_id, user):
-    @socketio.on('join game')
-    def return_join_game_notice(data):
-        game = data['game']
-        join_room(game)
-        emit('join game', data, room=f'game')
-
-# @socketio.on
-# def room_socket(roomspace):
-#     pass


### PR DESCRIPTION
Fixes #13 by renaming socket.io reserved event 'message' to 'send message'

Separate global namespace socket events from game room specific socket events
